### PR TITLE
Spot killer adjustment and tuning

### DIFF
--- a/Teensy code/vst_Colour_Mod_v3/advmame.cpp
+++ b/Teensy code/vst_Colour_Mod_v3/advmame.cpp
@@ -13,7 +13,7 @@
 #include "settings.h"
 
 char const *json_opts[] = {"\"productName\"", "\"version\"", "\"flipx\"", "\"flipy\"", "\"swapxy\"", "\"bwDisplay\"", "\"vertical\"", "\"crtSpeed\"", "\"crtJumpSpeed\"", "\"remote\"", "\"crtType\"", "\"defaultGame\""};
-char const *json_vals[] = {"\"VSTCM\"", "\"V3.0FC\"", "false", "false", "false", "false", "false", "15", "9", "true", "\"CUSTOM\"", "\"none\""};
+char const *json_vals[] = {"\"VSTCM\"", "\"V3.0\"", "false", "false", "false", "false", "false", "15", "9", "true", "\"CUSTOM\"", "\"none\""};
 static char json_str[MAX_JSON_STR_LEN];
 
 extern params_t v_config[NB_PARAMS];
@@ -80,7 +80,7 @@ int read_data(int init)
     return 0;
 
   frame_offset = 0;
-
+  
   uint8_t header = (cmd >> 29) & 0b00000111;
 
   //common case first

--- a/Teensy code/vst_Colour_Mod_v3/advmame.cpp
+++ b/Teensy code/vst_Colour_Mod_v3/advmame.cpp
@@ -19,6 +19,7 @@ static char json_str[MAX_JSON_STR_LEN];
 extern params_t v_config[NB_PARAMS];
 extern unsigned long dwell_time;
 extern float line_draw_speed;
+extern bool spot_triggered;
 
 // Read data from Raspberry Pi or other external computer
 // using AdvanceMAME protocol published here
@@ -119,8 +120,8 @@ int read_data(int init)
     // Not sure what to do differently if monochrome frame complete??
     // Add FPS on games as a guide for optimisation
     if (v_config[9].pval == true) 
-    {
-      draw_string("DT:", 3000, 150, 6, v_config[13].pval);
+    { if (spot_triggered) draw_string("*DT:", 3000, 150, 6, v_config[13].pval);
+      else draw_string("DT:", 3000, 150, 6, v_config[13].pval);
       // draw_string("DS:", 3000, 150, 6, v_config[13].pval);
       // draw_string(itoa(line_draw_speed*NORMAL_SHIFT_SCALING, buf1, 10), 3400, 150, 6, v_config[13].pval);
       draw_string(itoa(dwell_time, buf1, 10), 3400, 150, 6, v_config[13].pval);

--- a/Teensy code/vst_Colour_Mod_v3/buttons.cpp
+++ b/Teensy code/vst_Colour_Mod_v3/buttons.cpp
@@ -9,7 +9,10 @@
 
 #include <Bounce2.h>
 #include "settings.h"
-
+#ifdef IR_REMOTE
+#define SUPPRESS_ERROR_MESSAGE_FOR_BEGIN
+#include <IRremote.hpp>
+#endif
 // Bounce objects to read five pushbuttons (pins 0-4)
 static Bounce button0 = Bounce();
 static Bounce button1 = Bounce();

--- a/Teensy code/vst_Colour_Mod_v3/settings.cpp
+++ b/Teensy code/vst_Colour_Mod_v3/settings.cpp
@@ -21,7 +21,7 @@ params_t v_config[NB_PARAMS] = {
   {"OFF_DWELL0",       "Beam settling delay",              OFF_DWELL0,       0,        50},
   {"OFF_DWELL1",       "Wait before beam transit",         OFF_DWELL1,       0,        50},
   {"OFF_DWELL2",       "Wait after beam transit",          OFF_DWELL2,       0,        50},
-  {"NORMAL_SHIFT",     "Normal shift",                     NORMAL_SHIFT,     1,       255},
+  {"NORMAL_SHIFT",     "Drawing Speed",                     NORMAL_SHIFT,     1,       255},
   {"FLIP_X",           "Flip X axis",                      FLIP_X,           0,         1},
   {"FLIP_Y",           "Flip Y axis",                      FLIP_Y,           0,         1},
   {"SWAP_XY",          "Swap XY",                          SWAP_XY,          0,         1},

--- a/Teensy code/vst_Colour_Mod_v3/settings.h
+++ b/Teensy code/vst_Colour_Mod_v3/settings.h
@@ -11,6 +11,9 @@
 #define _settings_h_
 
 #include <stdio.h>
+
+#define IR_REMOTE                      // define if IR remote is fitted  TODO:deactivate if the menu is not shown? Has about a 10% reduction of frame rate when active
+
 //
 // Test pattern definitions
 //

--- a/Teensy code/vst_Colour_Mod_v3/settings.h
+++ b/Teensy code/vst_Colour_Mod_v3/settings.h
@@ -28,11 +28,11 @@ const int MAX_PTS = 3000;
 //
 // Definitions related to settings with default values
 //
-const int  OFF_SHIFT      =     9;     // Smaller numbers == slower transits (the higher the number, the less flicker and faster draw but more wavy lines)
+const int  OFF_SHIFT      =     8;     // Smaller numbers == slower transits (the higher the number, the less flicker and faster draw but more wavy lines)
 const int  OFF_DWELL0     =     6;     // Time to wait after changing the beam intensity (settling time for intensity DACs and monitor)
 const int  OFF_DWELL1     =     0;     // Time to sit before starting a transit
 const int  OFF_DWELL2     =     0;     // Time to sit after finishing a transit
-const int  NORMAL_SHIFT   =     4;     // The higher the number, the less flicker and faster draw but more wavy lines
+const int  NORMAL_SHIFT   =     2;     // The higher the number, the less flicker and faster draw but more wavy lines
 const bool SHOW_DT       = true;
 const bool FLIP_X         = false;     // Sometimes the X and Y need to be flipped and/or swapped
 const bool FLIP_Y         = false;

--- a/Teensy code/vst_Colour_Mod_v3/settings.h
+++ b/Teensy code/vst_Colour_Mod_v3/settings.h
@@ -32,7 +32,7 @@ const int  OFF_SHIFT      =     8;     // Smaller numbers == slower transits (th
 const int  OFF_DWELL0     =     6;     // Time to wait after changing the beam intensity (settling time for intensity DACs and monitor)
 const int  OFF_DWELL1     =     0;     // Time to sit before starting a transit
 const int  OFF_DWELL2     =     0;     // Time to sit after finishing a transit
-const int  NORMAL_SHIFT   =     2;     // The higher the number, the less flicker and faster draw but more wavy lines
+const int  NORMAL_SHIFT   =     3;     // The higher the number, the less flicker and faster draw but more wavy lines
 const bool SHOW_DT       = true;
 const bool FLIP_X         = false;     // Sometimes the X and Y need to be flipped and/or swapped
 const bool FLIP_Y         = false;

--- a/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
+++ b/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
@@ -29,7 +29,7 @@ const int REST_Y       = 2048;
 
 //For spot killer fix - if the total distance in x or y is less than SPOT_MAX, it will go to the corners to try to stop
 //the spot killer from triggering
-const int SPOT_MAX     = 3300;
+const int SPOT_MAX     = 3400;
 const int SPOT_GOTOMAX = 4076;
 const int SPOT_GOTOMIN = 20;
 

--- a/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
+++ b/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
@@ -18,11 +18,8 @@
 #include "spi_fct.h"
 #include "buttons.h"
 
-#define IR_REMOTE                      // define if IR remote is fitted  TODO:deactivate if the menu is not shown? Has about a 10% reduction of frame rate when active
-#ifdef IR_REMOTE
-#define SUPPRESS_ERROR_MESSAGE_FOR_BEGIN
-#include <IRremote.hpp>
-#endif
+
+
 
 const int REST_X       = 2048;     // Wait in the middle of the screen
 const int REST_Y       = 2048;

--- a/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
+++ b/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
@@ -171,13 +171,13 @@ void loop()
       draw_moveto (SPOT_GOTOMIN, SPOT_GOTOMIN);
       SPI_flush();
       delayMicroseconds(100);
-      if (dwell_time > 15) // For really long dwell times, do the moves again
+      if (dwell_time > 10) // For really long dwell times, do the moves again
         draw_moveto (SPOT_GOTOMAX, SPOT_GOTOMAX); //If we have time, do the moves again
         SPI_flush();
-        delayMicroseconds(100);
+        delayMicroseconds(200);
         draw_moveto (SPOT_GOTOMIN, SPOT_GOTOMIN); //Try to move back to the min again
         SPI_flush();
-        delayMicroseconds(100);
+        delayMicroseconds(200);
     }
     else spot_triggered=false;
   }

--- a/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
+++ b/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
@@ -167,10 +167,12 @@ void loop()
       spot_triggered=true;
       draw_moveto (SPOT_GOTOMAX, SPOT_GOTOMAX);
       SPI_flush();
-      delayMicroseconds(100);
+      if (dwell_time>5)delayMicroseconds(200);
+      else delayMicroseconds(100);
       draw_moveto (SPOT_GOTOMIN, SPOT_GOTOMIN);
       SPI_flush();
-      delayMicroseconds(100);
+      if (dwell_time>5)delayMicroseconds(200);
+      else delayMicroseconds(100);
       if (dwell_time > 10) // For really long dwell times, do the moves again
         draw_moveto (SPOT_GOTOMAX, SPOT_GOTOMAX); //If we have time, do the moves again
         SPI_flush();

--- a/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
+++ b/Teensy code/vst_Colour_Mod_v3/vst_Colour_Mod_v3.ino
@@ -27,17 +27,20 @@
 const int REST_X       = 2048;     // Wait in the middle of the screen
 const int REST_Y       = 2048;
 
-//For spot killer fix - if the min or max is beyond these limits we will go to the appropriate side
-const int SPOT_MAX     = 3500;
-const int SPOT_GOTOMAX = 4050;
-const int SPOT_GOTOMIN = 40;
+//For spot killer fix - if the total distance in x or y is less than SPOT_MAX, it will go to the corners to try to stop
+//the spot killer from triggering
+const int SPOT_MAX     = 3300;
+const int SPOT_GOTOMAX = 4076;
+const int SPOT_GOTOMIN = 20;
+
+bool spot_triggered;
 
 //EXPERIMENTAL automatic draw rate adjustment based on how much idle time there is between frames
 //Defines and global for the auto-speed feature
 #define NORMAL_SHIFT_SCALING   2.0
 #define MAX_DELTA_SHIFT        6    // These are the limits on the auto-shift for speeding up drawing complex frames
 #define MIN_DELTA_SHIFT       -3
-#define DELTA_SHIFT_INCREMENT  0.2
+#define DELTA_SHIFT_INCREMENT  0.1
 #define SPEEDUP_THRESHOLD_MS   2    // If the dwell time is less than this then the drawing rate will try to speed up (lower resolution)
 #define SLOWDOWN_THRESHOLD_MS  8    // If the dwell time is greater than this then the drawing rate will slow down (higher resolution)
 //If the thresholds are too close together there can be "blooming" as the rate goes up and down too quickly - maybe make it limit the
@@ -129,7 +132,7 @@ void loop()
   if (show_vstcm_config)
   {
     delta_shift = 0;
-    line_draw_speed = (float)v_config[5].pval / NORMAL_SHIFT_SCALING + 1.0 ;
+    line_draw_speed = (float)v_config[5].pval / NORMAL_SHIFT_SCALING + 3.0 ; //Make things a little bit faster for the menu
     show_vstcm_config_screen();      // Show settings screen and manage associated control buttons
   }
   else
@@ -159,14 +162,24 @@ void loop()
   
   if (!show_vstcm_config)
   {
-    if (((frame_max_x - frame_min_x) < SPOT_MAX) || ((frame_max_y - frame_min_y) < SPOT_MAX))
+    if (((frame_max_x - frame_min_x) < SPOT_MAX) || ((frame_max_y - frame_min_y) < SPOT_MAX) || (dwell_time > 10))
     {
+      spot_triggered=true;
       draw_moveto (SPOT_GOTOMAX, SPOT_GOTOMAX);
+      SPI_flush();
+      delayMicroseconds(100);
       draw_moveto (SPOT_GOTOMIN, SPOT_GOTOMIN);
-
-      if (dwell_time > 3)
-        draw_moveto (SPOT_GOTOMAX, SPOT_GOTOMAX); //If we have time, do a move back all the way to the max
+      SPI_flush();
+      delayMicroseconds(100);
+      if (dwell_time > 15) // For really long dwell times, do the moves again
+        draw_moveto (SPOT_GOTOMAX, SPOT_GOTOMAX); //If we have time, do the moves again
+        SPI_flush();
+        delayMicroseconds(100);
+        draw_moveto (SPOT_GOTOMIN, SPOT_GOTOMIN); //Try to move back to the min again
+        SPI_flush();
+        delayMicroseconds(100);
     }
+    else spot_triggered=false;
   }
   
   goto_xy(REST_X, REST_Y);


### PR DESCRIPTION
The spot killer moves will now happen if there is enough time in the frame, even if the min and max are in range.  This keeps the spot killer on the newer 6100s and repros (most sensitive) from triggering on some games like space fury